### PR TITLE
Add Trailway Chrome extension to homepage projects

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,7 +18,8 @@ title: Home
 ![Peter Blanco - Product Manager and Tech Professional](/assets/home.jpg){: .intro-img }
 
 ## Latest projects & explorations
-- **Sep 2025**: Automating acceptance testing for Product Managers and Designers.  
+- **Oct 2025**: [Trailway Chrome Extension](https://chromewebstore.google.com/detail/dnecicegfbfoiipbiniljinalklfeaak){:target="_blank"} – Capture annotated screenshots, edit copy, block network requests, and test inputs without leaving the page.
+- **Sep 2025**: Automating acceptance testing for Product Managers and Designers.
 - **Aug 2025**: [Stevens](https://heystevens.com){:target="_blank"} – Stevens automates your email inbox, with smart labeling, auto archiving, and drafts that sound like you. Invite only
 - **June 2025**: [ThirdSpace ](https://www.getthirdspaces.com){:target="_blank"} – (no longer active) Discover, book, and pay in minutes for private bar events in NYC. [Read the postmortem &rarr;](/startup/thirdspaces-we-found-a-problem-but-no-business/)
 - **June 2025**: [Trailway](https://www.trailway.ai){:target="_blank"} - AI-powered user interviews.


### PR DESCRIPTION
## Summary
- add the new Trailway Chrome extension to the Latest projects & explorations list on the homepage

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910fd8e6000832caaafb81e62b14538)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an Oct 2025 entry for the Trailway Chrome Extension to the homepage projects list and reorders September beneath it.
> 
> - **Homepage (`index.md`)**:
>   - **Latest projects**: Add Oct 2025 entry for `Trailway Chrome Extension` with external link and short feature blurb.
>   - Reorder list so Sep 2025 entry follows the new Oct 2025 item.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d3009b6cd61176d7e4d3d857f065a7a140a9636. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->