### PR TITLE
Add Conductor setup script

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "setup": "bundle install"
+  }
+}


### PR DESCRIPTION
Adds a repo-level conductor.json with scripts.setup set to bundle install so new Conductor workspaces install the Jekyll dependencies using the existing Bundler workflow. Validated with bundle install and bundle exec jekyll build.